### PR TITLE
Fixed Defensive stance check

### DIFF
--- a/BuffBlock.lua
+++ b/BuffBlock.lua
@@ -190,19 +190,15 @@ function Kill_Buffs()
 			end
 		end
 		if BUFF_CONFIG[BB_PlayerName].SALVATION then
-			if (string.lower(UnitClass("player")) ~= "warrior" or (IsShieldEquipped() and GetShapeshiftFormInfo(2))) then
-				if (string.find(texture,"SealOfSalvation")) then
-					CancelPlayerBuff(buffIndex);
-					DEFAULT_CHAT_FRAME:AddMessage("Blocked "..BuffBlockMenuStrings[01], 1, 1, 0.5);
-				end
+			if (string.find(texture,"SealOfSalvation")) then
+				CancelPlayerBuff(buffIndex);
+				DEFAULT_CHAT_FRAME:AddMessage("Blocked "..BuffBlockMenuStrings[01], 1, 1, 0.5);
 			end
 		end
 		if BUFF_CONFIG[BB_PlayerName].GREATERSALVATION then
-			if (string.lower(UnitClass("player")) ~= "warrior" or (IsShieldEquipped() and GetShapeshiftFormInfo(2))) then
-				if (string.find(texture,"GreaterBlessingofSalvation")) then
-					CancelPlayerBuff(buffIndex);
-					DEFAULT_CHAT_FRAME:AddMessage("Blocked "..BuffBlockMenuStrings[02], 1, 1, 0.5);
-				end
+			if (string.find(texture,"GreaterBlessingofSalvation")) then
+				CancelPlayerBuff(buffIndex);
+				DEFAULT_CHAT_FRAME:AddMessage("Blocked "..BuffBlockMenuStrings[02], 1, 1, 0.5);
 			end
 		end
 		if BUFF_CONFIG[BB_PlayerName].DIVINESPIRIT then

--- a/BuffBlock.lua
+++ b/BuffBlock.lua
@@ -348,25 +348,15 @@ function IsBearForm()
 end
 
 function IsDefensiveStanceOn()
-    local buff = {"Ability_Warrior_DefensiveStance"}
-    local counter = 0
-    while GetPlayerBuff(counter) >= 0 do
-        local index, FindDS = GetPlayerBuff(counter)
-        if FindDS == 1 then
-            local texture = GetPlayerBuffTexture(index)
-            if texture then  -- Check if texture is not nil
-                local i = 1
-                while buff[i] do
-                    if string.find(texture, buff[i]) then
-                        return true
-                    end
-                    i = i + 1
-                end
-            end
-        end
-        counter = counter + 1
-    end
-    return false
+	local i;
+	local max = GetNumShapeshiftForms();
+	for i = 1 , max do
+		local _, name, isActive = GetShapeshiftFormInfo(i);
+		if(isActive and PlayerClass("Warrior", "player") and (name == "Defensive Stance")) then
+			return true
+		end
+	end
+	return false
 end
 
 SBBFrame = CreateFrame("Frame", nil, UIParent)


### PR DESCRIPTION
Fixed the check for warrior's defensive stance. Addon now properly blocks salvation in defensive stance, even when dual-wielding